### PR TITLE
changed quick zoom to min/max not linear order

### DIFF
--- a/wave_viewer.m
+++ b/wave_viewer.m
@@ -1953,8 +1953,6 @@ if length(t_user_events) >= 2
     tmarker_buffer = 0.05;
     t_low = min(t_user_events) - tmarker_buffer; 
     t_hi = max(t_user_events) + tmarker_buffer; 
-%     t_low = t_user_events(1) - tmarker_buffer;
-%     t_hi = t_user_events(end) + tmarker_buffer;
 elseif length(t_user_events) == 1
     tmarker_buffer = 0.2;
     t_low = t_user_events(1) - tmarker_buffer;

--- a/wave_viewer.m
+++ b/wave_viewer.m
@@ -1951,8 +1951,10 @@ function expand_btw_ax_uev(ax,tAx,fAx)
 fig_params = get_fig_params;
 if length(t_user_events) >= 2
     tmarker_buffer = 0.05;
-    t_low = t_user_events(1) - tmarker_buffer;
-    t_hi = t_user_events(end) + tmarker_buffer;
+    t_low = min(t_user_events) - tmarker_buffer; 
+    t_hi = max(t_user_events) + tmarker_buffer; 
+%     t_low = t_user_events(1) - tmarker_buffer;
+%     t_hi = t_user_events(end) + tmarker_buffer;
 elseif length(t_user_events) == 1
     tmarker_buffer = 0.2;
     t_low = t_user_events(1) - tmarker_buffer;


### PR DESCRIPTION
I have changed the functionality of the shortcut "q" for "quick zoom" so that it zooms into the temporally first and last events. Previously it would zoom into the first and last events in the vector, even if the last added event was earlier than the temporally last event. (Same for temporally vs. vectorally first event, but that has never actually been an issue yet.)