### PR TITLE
ue performance improvements

### DIFF
--- a/wave_viewer.m
+++ b/wave_viewer.m
@@ -1688,11 +1688,7 @@ else
         if ~isfield(marker_name_spec,'iidatsource4ypos'), marker_name_spec.iidatsource4ypos = []; end
         marker_name_spec.h_tmarker = h_tmarker;
         marker_name_str = get_marker_name_str(marker_name_spec,t);
-        cur_hax = gca;
- 
-%          axes(hax);  % because the text() command only works with the current axes 
-        h_marker_name(i_marker_name) = text(hax,t,tmarker_ydat(2),marker_name_str); % text(hax,...) updates axes automatically
-%         axes(cur_hax);
+        h_marker_name(i_marker_name) = text(hax,t,tmarker_ydat(2),marker_name_str);
 
         set(h_marker_name(i_marker_name),'VerticalAlignment',marker_name_spec.vert_align);
         if strcmp(marker_name_spec.color,'same')

--- a/wave_viewer.m
+++ b/wave_viewer.m
@@ -1689,7 +1689,6 @@ else
         marker_name_spec.h_tmarker = h_tmarker;
         marker_name_str = get_marker_name_str(marker_name_spec,t);
         h_marker_name(i_marker_name) = text(hax,t,tmarker_ydat(2),marker_name_str);
-
         set(h_marker_name(i_marker_name),'VerticalAlignment',marker_name_spec.vert_align);
         if strcmp(marker_name_spec.color,'same')
             set(h_marker_name(i_marker_name),'Color',get(h_tmarker,'Color'));
@@ -1703,7 +1702,6 @@ end
 set(h_tmarker,'UserData',h_marker_name);
 if ~yes_visible, set(h_tmarker,'Visible','off'); end
 end
-
 
 function update_tmarker(h_tmarker,t)
 if isempty(t)

--- a/wave_viewer.m
+++ b/wave_viewer.m
@@ -1689,9 +1689,11 @@ else
         marker_name_spec.h_tmarker = h_tmarker;
         marker_name_str = get_marker_name_str(marker_name_spec,t);
         cur_hax = gca;
-        axes(hax);  % because the text() command only works with the current axes 
-        h_marker_name(i_marker_name) = text(t,tmarker_ydat(2),marker_name_str);
-        axes(cur_hax);
+ 
+%          axes(hax);  % because the text() command only works with the current axes 
+        h_marker_name(i_marker_name) = text(hax,t,tmarker_ydat(2),marker_name_str); % text(hax,...) updates axes automatically
+%         axes(cur_hax);
+
         set(h_marker_name(i_marker_name),'VerticalAlignment',marker_name_spec.vert_align);
         if strcmp(marker_name_spec.color,'same')
             set(h_marker_name(i_marker_name),'Color',get(h_tmarker,'Color'));
@@ -1705,6 +1707,7 @@ end
 set(h_tmarker,'UserData',h_marker_name);
 if ~yes_visible, set(h_tmarker,'Visible','off'); end
 end
+
 
 function update_tmarker(h_tmarker,t)
 if isempty(t)


### PR DESCRIPTION
To improve the load time for user events. Previously, a separate call to cur_hax (the previous axis information) was required to restore properties of user events.

What we tried:
Separate function call: axes creation within for-loop was slow, so we moved it to another function and called it from make_tmarker
Parallel programming: create multiple 'workers' to perform tasks simultaneously (create all the user events at once)

Final changes:
Add the 'hax' parameter to the text function call. 

Edge cases tested:
Multiple overlapping events
Deleting multiple events and reloading audioGUI
Moving user events and expanding
Changing pre-emphasis or LPC order

Running profiler, we observe the following for make_tmarker:

For a trial with 3 user events, an ~87% decrease in runtime is observed.

Test 1:
Before: 1.086 seconds
After: 0.144 seconds

Test 2:
Before: 1.085 seconds
After: 0.148 seconds

etc.


For a trial with 20 user events, a ~95% decrease in runtime is observed.
Before: 4.947 seconds
After: 0.210 seconds

etc.