### PR TITLE
Quick zoom works better with forced aligner user events

### DIFF
--- a/wave_viewer.m
+++ b/wave_viewer.m
@@ -2096,9 +2096,17 @@ sorted_t_user_events = sort(t_user_events);
 num_user_events = length(t_user_events);
 
 fig_params = get_fig_params;
+
+% if 2 or more UEVs, zoom to include all events plus small buffer.
+% If 1 UEV, zoom to include event plus bigger buffer on each side.
+% If no UEVs, zoom to include all tracked formants plus small buffer.
 if num_user_events >= 2
     tmarker_buffer = 0.05;
     [t_low, lowix] = min(sorted_t_user_events); 
+    
+    % if the lowest user event is near zero, or highest user event is near
+    % the end of the trial, quickzoom to non-endpoint UEVs if they exist.
+    % This comes up most often with UEVs populated by a forced aligner.
     if t_low==0 && num_user_events>2
         t_low = sorted_t_user_events(lowix+1); 
     end

--- a/wave_viewer.m
+++ b/wave_viewer.m
@@ -2090,12 +2090,23 @@ end
 
 function expand_btw_ax_uev(ax,tAx,fAx) 
 [~,t_spec,~,t_user_events] = get_ax_tmarker_times(ax);
+sorted_t_user_events = sort(t_user_events); 
+trialdur = tAx(1).XLim(2); 
 
 fig_params = get_fig_params;
 if length(t_user_events) >= 2
     tmarker_buffer = 0.05;
-    t_low = min(t_user_events) - tmarker_buffer; 
-    t_hi = max(t_user_events) + tmarker_buffer; 
+    [t_low, lowix] = min(sorted_t_user_events); 
+    if t_low == 0
+        t_low = sorted_t_user_events(lowix+1); 
+    end
+    t_low = t_low - tmarker_buffer; 
+
+    [t_hi, hix] = max(sorted_t_user_events); 
+    if t_hi == trialdur
+        t_hi = sorted_t_user_events(hix-1); 
+    end
+    t_hi = t_hi + tmarker_buffer; 
 elseif length(t_user_events) == 1
     tmarker_buffer = 0.2;
     t_low = t_user_events(1) - tmarker_buffer;

--- a/wave_viewer.m
+++ b/wave_viewer.m
@@ -2089,21 +2089,23 @@ end
 end
 
 function expand_btw_ax_uev(ax,tAx,fAx) 
+axinfo = get(ax,'UserData');
+trialdur = axinfo.t_hlim;
 [~,t_spec,~,t_user_events] = get_ax_tmarker_times(ax);
 sorted_t_user_events = sort(t_user_events); 
-trialdur = tAx(1).XLim(2); 
+num_user_events = length(t_user_events);
 
 fig_params = get_fig_params;
-if length(t_user_events) >= 2
+if num_user_events >= 2
     tmarker_buffer = 0.05;
     [t_low, lowix] = min(sorted_t_user_events); 
-    if t_low == 0
+    if t_low==0 && num_user_events>2
         t_low = sorted_t_user_events(lowix+1); 
     end
     t_low = t_low - tmarker_buffer; 
 
     [t_hi, hix] = max(sorted_t_user_events); 
-    if t_hi == trialdur
+    if abs(t_hi-trialdur)<0.004 && num_user_events > 2
         t_hi = sorted_t_user_events(hix-1); 
     end
     t_hi = t_hi + tmarker_buffer; 


### PR DESCRIPTION
If there are user events at the very beginning or very end of a trial and there are also other user events, then ignore the first and last user events for the purposes of quick zooming (using 'q' to zoom to a relevant portion of the audio track). This most often happens with data that has been forced aligned. Now, instead of quickzoom not zooming in at all on forced aligned data, quickzoom will often be able to zoom to the relevant portion of the trial.